### PR TITLE
Update deploy-shiny.yaml with rsconnect 0.8.29

### DIFF
--- a/.github/workflows/deploy-shiny.yaml
+++ b/.github/workflows/deploy-shiny.yaml
@@ -68,7 +68,8 @@ jobs:
       - name: Install rsconnect
         shell: Rscript {0}
         run: |
-          install.packages("rsconnect")
+          if (!requireNamespace("renv", quietly = TRUE)) install.packages("renv")
+          renv::install("rsconnect@0.8.29")
          
 # Tokens are stored as secrets in GitHub to make sure only DfE analysts can publish apps in our shiny.io area
 # Navigate to Settings > Secrets to add and view secrets. These can also be things like admin login and passwords for SQL databases.


### PR DESCRIPTION
There's an issue with rsconnect versions 1.0 and 1.0.1 that means deployApp() requires manual input when called, causing deploys to fail on the build server when run via GitHub actions. As a workaround, I'm switching dashboard deploy scripts to run using rsconnect 0.8.29 instead.

I've discussed with Posit and sounds like they're planning on updating deployApp's behaviour on this front in a future release, but that may be a while off.