### PR TITLE
update sf as it doesn't work on shinyapps

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -1971,7 +1971,7 @@
     },
     "sf": {
       "Package": "sf",
-      "Version": "1.0-14",
+      "Version": "1.0-15",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [


### PR DESCRIPTION
Despite it installing on the test rigs just fine, sf 1.0-14 doesn't work in deploy, so updating to 1.0-15. No other changes.